### PR TITLE
Remove relationships conditionally

### DIFF
--- a/app/initializers/reopen-model.js
+++ b/app/initializers/reopen-model.js
@@ -52,7 +52,12 @@ export default {
             didUpdate: function() {
                 this.resetOldRelationships();
             },
-            rollbackAttributes: function() {
+            rollbackAttributes: function({ rollBackRelationships = true }) {
+                if (!rollBackRelationships) {
+                    this._super();
+                    return;
+                }
+
                 let oldRelationships = this.get('oldRelationships');
 
                 this.eachRelationship(function(name, descriptor) {

--- a/app/initializers/reopen-model.js
+++ b/app/initializers/reopen-model.js
@@ -52,7 +52,12 @@ export default {
             didUpdate: function() {
                 this.resetOldRelationships();
             },
-            rollbackAttributes: function() {
+            rollbackAttributes: function({ rollBackRelationships = false }) {
+                if (!rollBackRelationships) {
+                    this._super();
+                    return;
+                }
+
                 let oldRelationships = this.get('oldRelationships');
 
                 this.eachRelationship(function(name, descriptor) {


### PR DESCRIPTION
Allows the user to choose if he really wants rollback the relationships, and avoid change the default ember behavior.
This is usefull when the user has developed the project with the default ember behavior, install this plugin, will crash the older code.